### PR TITLE
Declared a constant to replace the repeated occurrence of the literal "TLSv1.3"

### DIFF
--- a/javalin-ssl/src/main/kotlin/io/javalin/community/ssl/TlsConfig.kt
+++ b/javalin-ssl/src/main/kotlin/io/javalin/community/ssl/TlsConfig.kt
@@ -1,4 +1,5 @@
 package io.javalin.community.ssl
+private const val TLS_VERSION = "TLSv1.3"
 
 /**
  * Data class for the SSL configuration.
@@ -32,7 +33,7 @@ class TlsConfig(
                 "TLS_AES_128_GCM_SHA256",
                 "TLS_AES_256_GCM_SHA384",
                 "TLS_CHACHA20_POLY1305_SHA256"),
-            arrayOf("TLSv1.3")
+            arrayOf(TLS_VERSION)
         )
         @Deprecated("Use TlsConfig.MODERN instead", ReplaceWith("TlsConfig.MODERN"))
         fun getMODERN(): TlsConfig = MODERN
@@ -52,7 +53,8 @@ class TlsConfig(
                 "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
                 "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
                 "TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
-            ), arrayOf("TLSv1.3","TLSv1.2")
+            ), 
+            arrayOf(TLS_VERSION, "TLSv1.2")
         )
         @Deprecated("Use TlsConfig.INTERMEDIATE instead", ReplaceWith("TlsConfig.INTERMEDIATE"))
         fun getINTERMEDIATE(): TlsConfig = INTERMEDIATE
@@ -89,7 +91,8 @@ class TlsConfig(
                 "TLS_RSA_WITH_AES_128_CBC_SHA",
                 "TLS_RSA_WITH_AES_256_CBC_SHA",
                 "TLS_RSA_WITH_3DES_EDE_CBC_SHA"
-            ), arrayOf("TLSv1.3","TLSv1.2", "TLSv1.1", "TLSv1")
+            ), 
+            arrayOf(TLS_VERSION,"TLSv1.2", "TLSv1.1", "TLSv1")
         )
         @Deprecated("Use TlsConfig.OLD instead", ReplaceWith("TlsConfig.OLD"))
         fun getOLD(): TlsConfig = OLD


### PR DESCRIPTION
**Thanks for your contribution.**

 **Technical Debt Description:**

In the file `TlsConfig.kt`, the string literal `"TLSv1.3"` was repeated multiple times across different configurations (`MODERN`, `INTERMEDIATE`, and `OLD`).
Such duplication increases redundancy and potential maintenance challenges.
To resolve this, I declared a constant to replace the repeated instances of `"TLSv1.3"`.

This change improves code readability, maintainability, and consistency across future updates.



 **Link to the Issue:**

**File:** `TlsConfig.kt`
**Path:** `javalin-ssl/src/main/kotlin/io/javalin/community/ssl/TlsConfig.kt`


 **Reason for Change:**

The repeated literal `"TLSv1.3"` was replaced with a constant `TLS_VERSION` to reduce redundancy and ensure that any future changes to the TLS version string only need to be made in one place.
This follows SonarQube rule **kotlin:S1192 (String literals should not be duplicated)**.

 **Changes Made:**

* Declared a constant `TLS_VERSION = "TLSv1.3"` at the top of the class.
* Replaced all hardcoded `"TLSv1.3"` values with the `TLS_VERSION` constant.


 **Closes <https://github.com/joykorji/javalin/issues/14>**

