### PR TITLE
Improve inadequate encryption strength

### DIFF
--- a/javalin-ssl/src/test/kotlin/io/javalin/community/ssl/IntegrationTestClass.kt
+++ b/javalin-ssl/src/test/kotlin/io/javalin/community/ssl/IntegrationTestClass.kt
@@ -116,7 +116,7 @@ abstract class IntegrationTestClass {
         @JvmStatic
         protected fun untrustedClientBuilder(): OkHttpClient.Builder {
             val sslContext: SSLContext = try {
-                SSLContext.getInstance("SSL")
+                SSLContext.getInstance("TLS")
             } catch (e: NoSuchAlgorithmException) {
                 throw RuntimeException(e)
             }

--- a/javalin/src/test/java/io/javalin/staticfiles/TestStaticFilesEdgeCases.kt
+++ b/javalin/src/test/java/io/javalin/staticfiles/TestStaticFilesEdgeCases.kt
@@ -166,7 +166,7 @@ class TestStaticFilesEdgeCases {
             override fun checkServerTrusted(a: Array<X509Certificate>, b: String) {}
             override fun getAcceptedIssuers() = arrayOf<X509Certificate>()
         })
-        val sslContext = SSLContext.getInstance("SSL")
+        val sslContext = SSLContext.getInstance("TLS")
             .also { it.init(null, trustAllCerts, SecureRandom()) }
         return OkHttpClient.Builder().apply {
             sslSocketFactory(sslContext.socketFactory, trustAllCerts[0])


### PR DESCRIPTION
resolves https://github.com/joykorji/javalin/issues/26

To implement secure HTTPS communication, using latest TLS version instead of SSL.